### PR TITLE
fix: changed postinstall script (#67)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "tsc",
     "pretty": "prettier --write \"./src/**/*.ts\" \"./tests/**/*.ts\"",
     "precommit": "lint-staged",
-    "postinstall": "./scripts/install_completion.js",
+    "postinstall": "node ./scripts/install_completion.js",
     "readme": "npm run build && node ./scripts/doc.js"
   },
   "lint-staged": {


### PR DESCRIPTION
I changed the postinstall script to to 'node ./scripts/install_completion.js'. This is neccessary to properly run the script on windows. Cf. Issue #67.