### PR TITLE
Fix uppercase variable in "validate" command

### DIFF
--- a/src/commands/pseudo.ts
+++ b/src/commands/pseudo.ts
@@ -41,7 +41,7 @@ function pseudoString(str: string) {
 }
 
 function pseudoExpression(msgid: string) {
-    const statement = <ExpressionStatement>tpl("`" + msgid + "`")();
+    const statement = <ExpressionStatement>tpl.ast("`" + msgid + "`");
     const expression = <TemplateLiteral>statement.expression;
 
     for (const q of expression.quasis) {

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -20,7 +20,7 @@ export function langValidationMsg(language: string): string {
 /* Parse template string with babel and return a Set of template identifiers and tagged expressions */
 export function parseTemplateString(str: string): Set<string> {
     const templates: Set<string> = new Set();
-    const expressionStmt = <ExpressionStatement>tpl("`" + str + "`")();
+    const expressionStmt = <ExpressionStatement>tpl.ast("`" + str + "`");
     // I cannot into types
     const expression = <TemplateLiteral>expressionStmt.expression;
     for (const node of expression.expressions) {

--- a/tests/commands/test_validate.ts
+++ b/tests/commands/test_validate.ts
@@ -13,6 +13,10 @@ test("parse template string", () => {
     expect(Array.from(taggedexpression.values()).join("|")).toBe(
         "x + z|y() * 5"
     );
+
+    // should work with upper case characters as variables (regression)
+    const uppercaseVariables = parseTemplateString("${X} and ${Y}");
+    expect(Array.from(uppercaseVariables.values()).join("|")).toBe("X|Y");
 });
 
 test("invalid format checks", () => {


### PR DESCRIPTION
### Issue
Fail to parse upper case variables when running `validate` command.

### Solution
Use `tpl.ast()` to parse the string, babel will not recognize it as placeholder. ([babel/babel#8723](https://github.com/babel/babel/issues/8723#issuecomment-422438777))

### Similar issue
ttag-org/babel-plugin-ttag#111