### PR TITLE
Implementation of the compact format for the JSON export

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ will parse and output po file as loadable JSON
 #### Arguments:
 	-pretty  --p   pretty print js  (default: false)
 	-nostrip  --n   do not strip comments/headers  (default: false)
+	--format  sets the output JSON format (compact is much smaller)
+        [choices: "compact", "verbose"] [default: "verbose"]
 
 
 <!--- END COMMANDS --->

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "devDependencies": {
     "@types/babel__core": "7.0.1",
     "@types/babel__generator": "^7.0.0",
+    "@types/babel__parser": "^7.0.0",
     "@types/babel__template": "^7.0.0",
     "@types/babel__traverse": "^7.0.0",
     "@types/chalk": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "@types/babel__core": "7.0.1",
     "@types/babel__generator": "^7.0.0",
-    "@types/babel__parser": "^7.0.0",
     "@types/babel__template": "^7.0.0",
     "@types/babel__traverse": "^7.0.0",
     "@types/chalk": "^2.2.0",

--- a/src/commands/po2json.ts
+++ b/src/commands/po2json.ts
@@ -1,13 +1,16 @@
-import { parse } from "../lib/parser";
-import { iterateTranslations } from "../lib/utils";
+import { parse, PoDataCompact, PoData } from "../lib/parser";
+import { iterateTranslations, convert2Compact } from "../lib/utils";
 import * as fs from "fs";
 
 export default function po2json(
     path: string,
     pretty: boolean,
-    nostrip: boolean
+    nostrip: boolean,
+    format: "compact" | "verbose"
 ) {
-    const poData = parse(fs.readFileSync(path).toString());
+    let poData: PoData | PoDataCompact = parse(
+        fs.readFileSync(path).toString()
+    );
     const messages = iterateTranslations(poData.translations);
     if (!nostrip) {
         const header = messages.next().value;
@@ -15,6 +18,9 @@ export default function po2json(
         for (const msg of messages) {
             delete msg.comments;
         }
+    }
+    if (format === "compact") {
+        poData = convert2Compact(poData);
     }
     process.stdout.write(JSON.stringify(poData, null, pretty ? 2 : 0));
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -289,10 +289,16 @@ yargs
                 description: "do not strip comments/headers",
                 boolean: true,
                 default: false
+            },
+            format: {
+                description:
+                    "sets the output JSON format (compact is much smaller)",
+                choices: ["compact", "verbose"],
+                default: "verbose"
             }
         },
         argv => {
-            po2js(argv.pofile, argv.pretty, argv.nostrip);
+            po2js(argv.pofile, argv.pretty, argv.nostrip, argv.format);
         }
     )
     .command("doc", false, {}, _ => {

--- a/src/lib/parser.ts
+++ b/src/lib/parser.ts
@@ -37,6 +37,11 @@ export type PoData = {
     charset?: string;
 };
 
+export type PoDataCompact = {
+    headers: { "plural-forms": string };
+    contexts: { [key: string]: { [key: string]: string[] } };
+};
+
 export function parse(str: string): PoData {
     return po.parse(str);
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { Translations, Message } from "./parser";
+import { Translations, Message, PoData, PoDataCompact } from "./parser";
 import generate from "@babel/generator";
 import { Node } from "@babel/types";
 
@@ -32,4 +32,28 @@ export function* iterateTranslations(
 
 export function ast2Str(ast: Node): string {
     return generate(ast).code;
+}
+
+export function convert2Compact(poData: PoData): PoDataCompact {
+    const compactPo: PoDataCompact = {
+        headers: {
+            "plural-forms": ""
+        },
+        contexts: {
+            "": {}
+        }
+    };
+    compactPo.headers["plural-forms"] = poData.headers["plural-forms"];
+    Object.entries(poData.translations).forEach(
+        ([context, ctxtTranslations]) => {
+            Object.entries(ctxtTranslations).forEach(([msgid, msgidData]) => {
+                if (!compactPo.contexts[context]) {
+                    compactPo.contexts[context] = {};
+                }
+                compactPo.contexts[context][msgid] = msgidData.msgstr;
+            });
+        }
+    );
+    delete compactPo.contexts[""][""];
+    return compactPo;
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -47,6 +47,12 @@ export function convert2Compact(poData: PoData): PoDataCompact {
     Object.entries(poData.translations).forEach(
         ([context, ctxtTranslations]) => {
             Object.entries(ctxtTranslations).forEach(([msgid, msgidData]) => {
+                if (msgidData.comments && msgidData.comments.flag == "fuzzy") {
+                    return;
+                }
+                if (!msgidData.msgstr.length) {
+                    return;
+                }
                 if (!compactPo.contexts[context]) {
                     compactPo.contexts[context] = {};
                 }

--- a/tests/commands/__snapshots__/test_po2js.ts.snap
+++ b/tests/commands/__snapshots__/test_po2js.ts.snap
@@ -47,3 +47,5 @@ exports[`convert po to js pretty 1`] = `
   }
 }"
 `;
+
+exports[`should apply compact format 1`] = `"{\\"headers\\":{\\"plural-forms\\":\\"nplurals=2; plural=(n!=1);\\"},\\"contexts\\":{\\"\\":{\\"test\\":[\\"test translated\\"]},\\"ctx1\\":{\\"test\\":[\\"test translated\\"]},\\"ctx2\\":{\\"test\\":[\\"test translated\\"]}}}"`;

--- a/tests/commands/test_po2js.ts
+++ b/tests/commands/test_po2js.ts
@@ -23,3 +23,12 @@ test("convert po to js nostrip", () => {
     ).toString();
     expect(result).toMatchSnapshot();
 });
+
+test("should apply compact format", () => {
+    const result = execSync(
+        `ts-node src/index.ts po2json --format=compact -n ${poPath}`
+    ).toString();
+    const jsonResult = JSON.parse(result);
+    expect(jsonResult).toHaveProperty("contexts");
+    expect(result).toMatchSnapshot();
+});

--- a/tests/lib/test_utils.ts
+++ b/tests/lib/test_utils.ts
@@ -105,16 +105,17 @@ describe("convert2Compact", () => {
                         comments: {
                             flag: "fuzzy"
                         }
+                    },
+                    test: {
+                        msgid: "test",
+                        msgstr: ["test [translation]"]
                     }
                 }
             }
         };
         const result = convert2Compact(verbose);
-        expect(result.contexts[""]).not.toHaveProperty("untranslated", [
-            "untranslated test [translation]"
-        ]);
-        expect(result.contexts[""]).not.toHaveProperty("fuzzy", [
-            "fuzzy test [translation]"
-        ]);
+        expect(result.contexts[""]).toHaveProperty("test");
+        expect(result.contexts[""]).not.toHaveProperty("untranslated");
+        expect(result.contexts[""]).not.toHaveProperty("fuzzy");
     });
 });

--- a/tests/lib/test_utils.ts
+++ b/tests/lib/test_utils.ts
@@ -87,4 +87,34 @@ describe("convert2Compact", () => {
             "ctx test [translation]"
         ]);
     });
+    test("should remove untranslated and fuzzy", () => {
+        const verbose = {
+            headers: {
+                "plural-forms": "nplurals=2; plural=(n!=1);\n",
+                other: "header"
+            },
+            translations: {
+                "": {
+                    untranslated: {
+                        msgid: "test",
+                        msgstr: []
+                    },
+                    fuzzy: {
+                        msgid: "test",
+                        msgstr: [],
+                        comments: {
+                            flag: "fuzzy"
+                        }
+                    }
+                }
+            }
+        };
+        const result = convert2Compact(verbose);
+        expect(result.contexts[""]).not.toHaveProperty("untranslated", [
+            "untranslated test [translation]"
+        ]);
+        expect(result.contexts[""]).not.toHaveProperty("fuzzy", [
+            "fuzzy test [translation]"
+        ]);
+    });
 });

--- a/tests/lib/test_utils.ts
+++ b/tests/lib/test_utils.ts
@@ -1,0 +1,90 @@
+import { convert2Compact } from "../../src/lib/utils";
+
+describe("convert2Compact", () => {
+    test("should strip headers except of plural-forms", () => {
+        const verbose = {
+            headers: {
+                "plural-forms": "nplurals=2; plural=(n!=1);\n",
+                other: "header"
+            },
+            translations: {
+                "": {}
+            }
+        };
+        const result = convert2Compact(verbose);
+        expect(result.headers).not.toHaveProperty("other");
+        expect(result.headers).toHaveProperty(
+            "plural-forms",
+            "nplurals=2; plural=(n!=1);\n"
+        );
+    });
+    test("should omit the empty string translation", () => {
+        const verbose = {
+            headers: {
+                "plural-forms": "nplurals=2; plural=(n!=1);\n",
+                other: "header"
+            },
+            translations: {
+                "": {
+                    "": {
+                        msgid: "",
+                        msgstr: [
+                            "Content-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nProject-Id-Version: protonmail\nPlural-Forms: nplurals=2; plural=(n != 1);\nX-Generator: crowdin.com\nX-Crowdin-Project: protonmail\nX-Crowdin-Language: pt-BR\nX-Crowdin-File: ProtonMail Web Application.pot\nLast-Translator: PMtranslator\nLanguage-Team: Portuguese, Brazilian\nLanguage: pt_BR\nPO-Revision-Date: 2019-04-17 08:44\n"
+                        ]
+                    }
+                }
+            }
+        };
+        const result = convert2Compact(verbose);
+        expect(result.contexts[""]).not.toHaveProperty("");
+    });
+    test("should transform poEntry", () => {
+        const verbose = {
+            headers: {
+                "plural-forms": "nplurals=2; plural=(n!=1);\n",
+                other: "header"
+            },
+            translations: {
+                "": {
+                    test: {
+                        msgid: "test",
+                        msgstr: ["test [translation]"]
+                    }
+                }
+            }
+        };
+        const result = convert2Compact(verbose);
+        expect(result.contexts[""]).toHaveProperty("test", [
+            "test [translation]"
+        ]);
+    });
+    test("should apply all contexts", () => {
+        const verbose = {
+            headers: {
+                "plural-forms": "nplurals=2; plural=(n!=1);\n",
+                other: "header"
+            },
+            translations: {
+                "": {
+                    test: {
+                        msgid: "test",
+                        msgstr: ["test [translation]"]
+                    }
+                },
+                ctx: {
+                    "ctx test": {
+                        msgid: "ctx test",
+                        msgstr: ["ctx test [translation]"]
+                    }
+                }
+            }
+        };
+        const result = convert2Compact(verbose);
+        expect(result.contexts[""]).toHaveProperty("test", [
+            "test [translation]"
+        ]);
+        expect(result.contexts["ctx"]).toHaveProperty("ctx test", [
+            "ctx test [translation]"
+        ]);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
     "compilerOptions": {
         "target": "es5",
         "outDir": "dist",
-        "lib":["es5", "es6", "dom"],
+        "lib":["es5", "es6", "es2017", "dom"],
         "strictNullChecks": true,
         "noImplicitAny": true,
         "noImplicitReturns": true,


### PR DESCRIPTION
Original issue - https://github.com/ttag-org/ttag-cli/issues/70

This PR introduces the new compact format, that is more suitable for the production.
The compact format can be enabled with `--format=compact` option :

```sh
ttag po2json --format=compact en.po > en.po.json
```

The old format is enabled by default and can be explicitly set with `--format=verbose` option.

We are going to enable compact format by default in a future `1.8.0` release (https://github.com/ttag-org/ttag/milestone/5).

<details>
<summary> The old format output example:</summary>

```json
{
  "charset": "utf-8",
  "headers": {
    "content-type": "text/plain; charset=UTF-8",
    "content-transfer-encoding": "8bit",
    "project-id-version": "protonmail",
    "plural-forms": "nplurals=2; plural=(n != 1);",
    "x-generator": "crowdin.com",
    "x-crowdin-project": "protonmail",
    "x-crowdin-language": "pt-BR",
    "x-crowdin-file": "ProtonMail Web Application.pot",
    "last-translator": "PMtranslator",
    "language-team": "Portuguese, Brazilian",
    "language": "pt_BR",
    "po-revision-date": "2019-04-17 08:44"
  },
  "translations": {
    "": {
      "": {
        "msgid": "",
        "msgstr": [
          "Content-Type: text/plain; charset=UTF-8\nContent-Transfer-Encoding: 8bit\nProject-Id-Version: protonmail\nPlural-Forms: nplurals=2; plural=(n != 1);\nX-Generator: crowdin.com\nX-Crowdin-Project: protonmail\nX-Crowdin-Language: pt-BR\nX-Crowdin-File: ProtonMail Web Application.pot\nLast-Translator: PMtranslator\nLanguage-Team: Portuguese, Brazilian\nLanguage: pt_BR\nPO-Revision-Date: 2019-04-17 08:44\n"
        ]
      }
    },
    "1 of 2 contacts successfully imported.": {
      "contacts successfully imported.": {
        "msgid": "contacts successfully imported.",
        "msgctxt": "1 of 2 contacts successfully imported.",
        "msgstr": [
          "contatos importados com sucesso."
        ]
      }
    },
    "1 of 2 contacts successfully merged.": {
      "contacts successfully merged.": {
        "msgid": "contacts successfully merged.",
        "msgctxt": "1 of 2 contacts successfully merged.",
        "msgstr": [
          "contatos mesclados com sucesso."
        ]
      }
    }
}
```
</details>

<details>
<summary>The new optimized format:</summary>

```json
{
  "headers": {
    "plural-forms": "nplurals=2; plural=(n != 1);"
  },
  "contexts": {
    "": {
    },
    "1 of 2 contacts successfully imported.": {
      "contacts successfully imported.": [
          "contatos importados com sucesso."
        ]
    },
    "1 of 2 contacts successfully merged.": {
      "contacts successfully merged.": [
          "contatos mesclados com sucesso."
        ]
      }
    }
}
```
</details>
