### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
   "devDependencies": {
     "@types/babel__core": "7.1.2",
     "@types/babel__generator": "^7.0.0",
-    "@types/babel__parser": "^7.0.0",
     "@types/babel__template": "^7.0.2",
     "@types/babel__traverse": "^7.0.0",
     "@types/chalk": "^2.2.0",


### PR DESCRIPTION
```
npm WARN deprecated @types/opn@5.5.0: This is a stub types definition. opn provides its own type definitions, so you do not need this installed.
```