### PR TITLE
Add support for TypeScript nullish coalescing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -547,6 +547,15 @@
         "@babel/plugin-syntax-json-strings": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-TbYHmr1Gl1UC7Vo2HVuj/Naci5BEGNZ0AJhzqD2Vpr6QPFWpUmBRLrIDjedzx7/CShq0bRDS2gI4FIs77VHLVQ==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.7.4"
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.5.4.tgz",
@@ -636,6 +645,14 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.0.0.tgz",
       "integrity": "sha512-PdmL2AoPsCLWxhIr3kG2+F9v4WH06Q3z+NoGVpQgnUNGcagXHq5sB3OXxkSahKq9TLdNMN/AJzFYSOo8UKDMHg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.7.4.tgz",
+      "integrity": "sha512-XKh/yIRPiQTOeBg0QJjEus5qiSKucKAiApNtO1psqG7D17xmE+X2i5ZqBEuSvo0HRuyPaKaSN/Gy+Ha9KFQolw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/plugin-proposal-class-properties": "^7.5.0",
     "@babel/plugin-proposal-decorators": "^7.4.4",
     "@babel/plugin-proposal-export-default-from": "^7.5.2",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.7.4",
     "@babel/plugin-proposal-object-rest-spread": "^7.5.4",
     "@babel/plugin-proposal-optional-chaining": "7.6.0",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",

--- a/src/declarations.ts
+++ b/src/declarations.ts
@@ -14,3 +14,4 @@ declare module "@babel/plugin-proposal-decorators";
 declare module "@babel/preset-typescript";
 declare module "@babel/preset-flow";
 declare module "@babel/plugin-proposal-optional-chaining";
+declare module "@babel/plugin-proposal-nullish-coalescing-operator";

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -14,6 +14,7 @@ import * as babelTtagPlugin from "babel-plugin-ttag";
 import * as babelDynamicImportPlugin from "@babel/plugin-syntax-dynamic-import";
 import * as babelPluginDecorators from "@babel/plugin-proposal-decorators";
 import * as optionalChaningPlugin from "@babel/plugin-proposal-optional-chaining";
+import * as nullishCoalescingOperatorPlugin from "@babel/plugin-proposal-nullish-coalescing-operator";
 
 export const defaultPlugins: ConfigItem[] = [
     [babelPluginDecorators, { legacy: true }],
@@ -21,7 +22,8 @@ export const defaultPlugins: ConfigItem[] = [
     restSpreadPlugin,
     exportDefaultFromPlugin,
     babelDynamicImportPlugin,
-    optionalChaningPlugin
+    optionalChaningPlugin,
+    nullishCoalescingOperatorPlugin
 ];
 
 export const defaultPresets: ConfigItem[] = [

--- a/tests/commands/__snapshots__/test_extract.ts.snap
+++ b/tests/commands/__snapshots__/test_extract.ts.snap
@@ -66,6 +66,18 @@ msgid \\"test \${ name }\\"
 msgstr \\"\\""
 `;
 
+exports[`extract from ts 3`] = `
+"msgid \\"\\"
+msgstr \\"\\"
+\\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+\\"Plural-Forms: nplurals=2; plural=(n!=1);\\\\n\\"
+
+#: tests/fixtures/tsNullishCoalescing.ts:5
+#, javascript-format
+msgid \\"test \${ name }\\"
+msgstr \\"\\""
+`;
+
 exports[`extract from tsx 1`] = `
 "msgid \\"\\"
 msgstr \\"\\"

--- a/tests/commands/test_extract.ts
+++ b/tests/commands/test_extract.ts
@@ -11,6 +11,10 @@ const jsxPath = path.resolve(__dirname, "../fixtures/testJSXParse.jsx");
 const globalFn = path.resolve(__dirname, "../fixtures/globalFunc.js");
 const tsPath = path.resolve(__dirname, "../fixtures/tSParse.ts");
 const tsChaning = path.resolve(__dirname, "../fixtures/tsOptionalChaning.ts");
+const tsCoalescing = path.resolve(
+    __dirname,
+    "../fixtures/tsNullishCoalescing.ts"
+);
 const tsxPath = path.resolve(__dirname, "../fixtures/tSXParse.tsx");
 
 function cleanup() {
@@ -85,6 +89,12 @@ test("should extract in the alphabetical order (sortByMsgid)", () => {
 
 test("extract from ts", () => {
     execSync(`ts-node src/index.ts extract -o ${potPath} ${tsChaning}`);
+    const result = fs.readFileSync(potPath).toString();
+    expect(result).toMatchSnapshot();
+});
+
+test("extract from ts", () => {
+    execSync(`ts-node src/index.ts extract -o ${potPath} ${tsCoalescing}`);
     const result = fs.readFileSync(potPath).toString();
     expect(result).toMatchSnapshot();
 });

--- a/tests/fixtures/tsNullishCoalescing.ts
+++ b/tests/fixtures/tsNullishCoalescing.ts
@@ -1,0 +1,6 @@
+import { t } from "ttag";
+
+function test(data) {
+    const name = data ?? 'default';
+    console.log(t`test ${name}`);
+}


### PR DESCRIPTION
New in TypeScript 3.7, nullish coalescing is part of the main language features and should be included in the base configuration of the Babel configuration.

I tried to stay faithful to the coding style and testing but happy to receive feedback 😃 

Nullish coalescing release notes: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#nullish-coalescing