### PR TITLE
Support extracting tags from Svelte files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > :warning: This project [was previously named `c-3po-cli`](https://github.com/ttag-org/ttag/issues/105).
 > Some of the talks, presentations, and documentation _may_ reference it with both names.
 
-Command line utility for [ttag](https://github.com/ttag-org/ttag) translation library. 
-Works out of the box with **js**, **ts**, **jsx**, **tsx**, **vue** files.
+Command line utility for [ttag](https://github.com/ttag-org/ttag) translation library.
+Works out of the box with **js**, **ts**, **jsx**, **tsx**, **vue**, **svelte**,  files.
 
 # Installation
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1909,6 +1909,15 @@
       "integrity": "sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=",
       "dev": true
     },
+    "@types/walk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@types/walk/-/walk-2.3.0.tgz",
+      "integrity": "sha512-I1w1RJW5kowe7JnekvVTSD/Lek8WK0N/Fz80n9Chnb5jYo+mne4tDthgCAV/Fo1tym9m8W6stfsJQvjRMpOHgw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/yargs": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3159,6 +3159,11 @@
       "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
       "dev": true
     },
+    "estree-walker": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.1.tgz",
+      "integrity": "sha512-tF0hv+Yi2Ot1cwj9eYHtxC0jB9bmjacjQs6ZBTj82H8JwUywFuc+7E83NWfNMwHXZc11mjfFcVXPe9gEP4B8dg=="
+    },
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
@@ -8355,6 +8360,11 @@
       "requires": {
         "has-flag": "^3.0.0"
       }
+    },
+    "svelte": {
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-3.20.1.tgz",
+      "integrity": "sha512-m/dw52BZf+p6KYnyKLErIcGalu4pwJrQbUM7VZriRw6ZlJj1qMAZsLcIWzEB3I0hhdJwkKb7LrrvUIeqmbO92Q=="
     },
     "symbol-observable": {
       "version": "0.2.4",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "babel-plugin-ttag": "^1.7.24",
     "chalk": "^2.4.2",
     "cross-spawn": "^5.1.0",
+    "estree-walker": "^2.0.1",
     "gettext-parser": "4.0.0-alpha.0",
     "htmlparser2": "^4.1.0",
     "hunspell-spellchecker": "^1.0.2",
@@ -84,6 +85,7 @@
     "readline-sync": "^1.4.7",
     "serialize-javascript": "^2.1.2",
     "supports-color": "^5.0.1",
+    "svelte": "^3.20.1",
     "tmp": "0.0.33",
     "walk": "2.3.9",
     "yargs": "^11.1.1"

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/readline-sync": "^1.4.2",
     "@types/serialize-javascript": "^1.5.0",
     "@types/tmp": "^0.0.33",
+    "@types/walk": "^2.3.0",
     "@types/yargs": "8.0.2",
     "babel-core": "^7.0.0-bridge.0",
     "husky": "^0.14.3",

--- a/src/lib/extract.ts
+++ b/src/lib/extract.ts
@@ -6,6 +6,7 @@ import { extname } from "path";
 import { Parser } from "htmlparser2";
 import { walk } from "estree-walker";
 import { parse as parseSvelte } from "svelte/compiler";
+import { TemplateNode } from "svelte/types/compiler/interfaces";
 import { makeBabelConf } from "../defaults";
 import * as ttagTypes from "../types";
 import { TransformFn, pathsWalk } from "./pathsWalk";
@@ -76,7 +77,7 @@ export async function extractAll(
                     // <script> tag should include `import {t } from 'ttag'`
                     // We put this in the front
                     walk(instance, {
-                        enter(node) {
+                        enter(node: TemplateNode) {
                             if (node.type !== "Program") return;
                             jsCodes.push(source.slice(node.start, node.end));
                         }
@@ -84,7 +85,7 @@ export async function extractAll(
 
                     // Collect t`...` in {...} in template
                     walk(html, {
-                        enter(node) {
+                        enter(node: TemplateNode) {
                             if (
                                 node.type !== "MustacheTag" &&
                                 node.type !== "RawMustacheTag"

--- a/src/lib/pathsWalk.ts
+++ b/src/lib/pathsWalk.ts
@@ -16,7 +16,8 @@ function walkFile(
         extname === ".jsx" ||
         extname === ".ts" ||
         extname === ".tsx" ||
-        extname === ".vue"
+        extname === ".vue" ||
+        extname === ".svelte"
     ) {
         progress.text = filepath;
         transformFn(filepath);

--- a/tests/commands/__snapshots__/test_extract.ts.snap
+++ b/tests/commands/__snapshots__/test_extract.ts.snap
@@ -42,6 +42,35 @@ msgid \\"test from jsx\\"
 msgstr \\"\\""
 `;
 
+exports[`extract from svelte 1`] = `
+"msgid \\"\\"
+msgstr \\"\\"
+\\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+\\"Plural-Forms: nplurals=2; plural=(n!=1);\\\\n\\"
+
+#: tests/fixtures/testSvelteParse.svelte:6
+msgid \\"world\\"
+msgstr \\"\\"
+
+#: tests/fixtures/testSvelteParse.svelte:8
+#, javascript-format
+msgid \\"Hello \${ translated } !\\"
+msgstr \\"\\"
+
+#: tests/fixtures/testSvelteParse.svelte:9
+msgid \\"Instruction\\"
+msgstr \\"\\"
+
+#: tests/fixtures/testSvelteParse.svelte:10
+#, javascript-format
+msgid \\"Click <a href=\${ moreUrl }>here</a> for more info\\"
+msgstr \\"\\"
+
+#: tests/fixtures/testSvelteParse.svelte:11
+msgid \\"Log out\\"
+msgstr \\"\\""
+`;
+
 exports[`extract from ts 1`] = `
 "msgid \\"\\"
 msgstr \\"\\"

--- a/tests/commands/test_extract.ts
+++ b/tests/commands/test_extract.ts
@@ -9,6 +9,10 @@ const sortByMsgidPath = path.resolve(__dirname, "../fixtures/sortByMsgidTest");
 const ukTestPath = path.resolve(__dirname, "../fixtures/ukLocaleTest");
 const jsxPath = path.resolve(__dirname, "../fixtures/testJSXParse.jsx");
 const vuePath = path.resolve(__dirname, "../fixtures/testVueParse.vue");
+const sveltePath = path.resolve(
+    __dirname,
+    "../fixtures/testSvelteParse.svelte"
+);
 const globalFn = path.resolve(__dirname, "../fixtures/globalFunc.js");
 const tsPath = path.resolve(__dirname, "../fixtures/tSParse.ts");
 const tsChaning = path.resolve(__dirname, "../fixtures/tsOptionalChaning.ts");
@@ -40,6 +44,12 @@ test("extract from jsx", () => {
 
 test("extract from vue", () => {
     execSync(`ts-node src/index.ts extract -o ${potPath} ${vuePath}`);
+    const result = fs.readFileSync(potPath).toString();
+    expect(result).toMatchSnapshot();
+});
+
+test.only("extract from svelte", () => {
+    execSync(`ts-node src/index.ts extract -o ${potPath} ${sveltePath}`);
     const result = fs.readFileSync(potPath).toString();
     expect(result).toMatchSnapshot();
 });

--- a/tests/commands/test_extract.ts
+++ b/tests/commands/test_extract.ts
@@ -48,7 +48,7 @@ test("extract from vue", () => {
     expect(result).toMatchSnapshot();
 });
 
-test.only("extract from svelte", () => {
+test("extract from svelte", () => {
     execSync(`ts-node src/index.ts extract -o ${potPath} ${sveltePath}`);
     const result = fs.readFileSync(potPath).toString();
     expect(result).toMatchSnapshot();

--- a/tests/fixtures/testSvelteParse.svelte
+++ b/tests/fixtures/testSvelteParse.svelte
@@ -1,0 +1,20 @@
+<script>
+	import { t } from 'ttag';
+
+  export let loggedIn = false;
+	export let moreUrl = 'http://ttag.js.org';
+	export let translated = t`world`;
+</script>
+
+<style>
+	h1 {
+		color: purple;
+	}
+</style>
+
+<h1>{t`Hello ${translated} !`}</h1>
+<p title={t`Instruction`}>{@html t`Click <a href=${moreUrl}>here</a> for more info`}</p>
+
+{#if loggedIn}
+	<button>{t`Log out`}</button>
+{/if}


### PR DESCRIPTION
Inspired by [Vue integration](https://github.com/ttag-org/ttag-cli/pull/93), I added tag extraction support for `svelte` files in this PR, which is the component file used in [Svelte](https://svelte.dev/).

In order to support extraction of `t` in template, I included `svelte` as dependency in order to leverage it's exposed built-in parser. However, it seems that the type definition in `svelte` lacks some dependency, which will trigger Typescript errors. I am new to Typescript and not very sure how we should handle this.

Also, `estree-walker` is included to walk through the AST -- which can be replaced by any other ESTree traversal tool.

Please let me know if there is any concern regarding this PR. Thanks!