### PR TITLE
Preserve message context when merging text

### DIFF
--- a/src/lib/merge.ts
+++ b/src/lib/merge.ts
@@ -68,7 +68,8 @@ export function mergeMessage(
         msgid: leftMessage.msgid,
         comments: mergeComments(leftMessage.comments, rightMessage.comments),
         msgstr: msgstr,
-        msgid_plural: leftMessage.msgid_plural
+        msgid_plural: leftMessage.msgid_plural,
+        msgctxt: leftMessage.msgctxt
     };
 }
 

--- a/tests/commands/test_update.ts
+++ b/tests/commands/test_update.ts
@@ -42,9 +42,7 @@ test("test update with multiple discover po (plugins settings override test)", (
     const tmpFile = tmp.fileSync();
     fs.writeFileSync(tmpFile.name, originalPo);
     execSync(
-        `ts-node src/index.ts update --discover=_ --discover=gettext ${
-            tmpFile.name
-        } ${srcPath}`
+        `ts-node src/index.ts update --discover=_ --discover=gettext ${tmpFile.name} ${srcPath}`
     );
     const result = fs.readFileSync(tmpFile.name).toString();
     expect(result).toContain('msgid "discover _ test"');
@@ -84,6 +82,17 @@ const contextTest = path.resolve(
 test("should extract from context", () => {
     const tmpFile = tmp.fileSync();
     fs.writeFileSync(tmpFile.name, originalPo);
+    execSync(`ts-node src/index.ts update ${tmpFile.name} ${contextTest}`);
+    const result = fs.readFileSync(tmpFile.name).toString();
+    expect(result).toContain('msgctxt "email"');
+    expect(result).toContain('msgid "context translation"');
+    tmpFile.removeCallback();
+});
+
+test("should extract context consistently", () => {
+    const tmpFile = tmp.fileSync();
+    fs.writeFileSync(tmpFile.name, originalPo);
+    execSync(`ts-node src/index.ts update ${tmpFile.name} ${contextTest}`);
     execSync(`ts-node src/index.ts update ${tmpFile.name} ${contextTest}`);
     const result = fs.readFileSync(tmpFile.name).toString();
     expect(result).toContain('msgctxt "email"');


### PR DESCRIPTION
This PR fixes #84 by preserving context in `mergeMessage()`.

### Root cause analysis
1. `mergeMessage(left, right)` in `lib/merge.ts` is only used in `lib/update.ts`, the function behind `ttag update` command. Its main function is to merge the comments of `left` and `right`.
2. Previously, `mergeMessage(left, right)` does not preserve `msgctxt` when merging comments.
3. Whenever `ttag update` is updating translation entries with the same `msgid` and `msgctxt`, it merges their comments but `mergeMessage(left, right)` omits their `msgctxt`, resulting in a merged translation entry with its `msgctxt` removed.
4. The next time `ttag update` is invoked, the entry in po file (with no `msgctxt`) and the entry extracted from source code (with `msgctxt`) are **regarded as different entries**, the one in po file is thus removed and the entry with `msgctxt` is added to po file again. This explains why `msgctxt` are always being added and removed.

### Proposed fix in this PR
1. A test that can reproduce the bug is introduced
2. Support `msgctxt` in `mergeMessage()`. Since `lib/update.ts` always ensures `leftMessage` and `rightMessage` are under same `msgctxt` and `msgid`, we can directly get the context from `leftMessage`. The logic is similar to how `msgid_plural` is supported.