### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,9 +74,9 @@
     "estree-walker": "^2.0.1",
     "gettext-parser": "4.0.0-alpha.0",
     "hunspell-spellchecker": "^1.0.2",
-    "koa": "^2.7.0",
-    "koa-body": "^2.5.0",
-    "koa-router": "^7.3.0",
+    "koa": "^2.13.0",
+    "koa-body": "^4.2.0",
+    "koa-router": "^9.1.0",
     "mkdirp": "^0.5.1",
     "node-fetch": "^1.7.3",
     "open": "^6.4.0",
@@ -89,7 +89,7 @@
     "tmp": "0.0.33",
     "vue-sfc-parser": "^0.1.2",
     "walk": "2.3.9",
-    "yargs": "^11.1.1"
+    "yargs": "^15.4.1"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
koa-body is vulnerable to arbitrary file read. The vulnerability exists as it is possible to copy a file that exists outside of the web server's scope, into the `/public` directory which can be publicly read.
yargs-parser is vulnerable to prototype pollution. The attack exists as it does not properly sanitize the key value provided by users, allowing the malicious properties of Object.prototype to be parsed or modified using a` __proto__` payload.