### PR TITLE
Svelte expressions should be extracted without babel syntax errors

### DIFF
--- a/tests/commands/__snapshots__/test_extract.ts.snap
+++ b/tests/commands/__snapshots__/test_extract.ts.snap
@@ -48,25 +48,41 @@ msgstr \\"\\"
 \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
 \\"Plural-Forms: nplurals=2; plural=(n!=1);\\\\n\\"
 
-#: tests/fixtures/testSvelteParse.svelte:6
+#: tests/fixtures/testSvelteParse.svelte:3
+msgid \\"String from module\\"
+msgstr \\"\\"
+
+#: tests/fixtures/testSvelteParse.svelte:9
 msgid \\"world\\"
 msgstr \\"\\"
 
-#: tests/fixtures/testSvelteParse.svelte:8
+#: tests/fixtures/testSvelteParse.svelte:12
 #, javascript-format
 msgid \\"Hello \${ translated } !\\"
 msgstr \\"\\"
 
-#: tests/fixtures/testSvelteParse.svelte:9
+#: tests/fixtures/testSvelteParse.svelte:13
 msgid \\"Instruction\\"
 msgstr \\"\\"
 
-#: tests/fixtures/testSvelteParse.svelte:10
+#: tests/fixtures/testSvelteParse.svelte:14
 #, javascript-format
 msgid \\"Click <a href=\${ moreUrl }>here</a> for more info\\"
 msgstr \\"\\"
 
-#: tests/fixtures/testSvelteParse.svelte:11
+#: tests/fixtures/testSvelteParse.svelte:16
+msgid \\"Title in obj\\"
+msgstr \\"\\"
+
+#: tests/fixtures/testSvelteParse.svelte:18
+msgid \\"True\\"
+msgstr \\"\\"
+
+#: tests/fixtures/testSvelteParse.svelte:18
+msgid \\"False\\"
+msgstr \\"\\"
+
+#: tests/fixtures/testSvelteParse.svelte:19
 msgid \\"Log out\\"
 msgstr \\"\\""
 `;

--- a/tests/fixtures/testSvelteParse.svelte
+++ b/tests/fixtures/testSvelteParse.svelte
@@ -1,9 +1,14 @@
-<script>
+<script context="module">
 	import { t } from 'ttag';
+	let moduleString = t`String from module`;
+</script>
+
+<script>
 
   export let loggedIn = false;
 	export let moreUrl = 'http://ttag.js.org';
 	export let translated = t`world`;
+
 </script>
 
 <style>
@@ -14,6 +19,14 @@
 
 <h1>{t`Hello ${translated} !`}</h1>
 <p title={t`Instruction`}>{@html t`Click <a href=${moreUrl}>here</a> for more info`}</p>
+
+<svelte:component
+	this={false}
+	objExpressionProp={{
+		title: t`Title in obj`,
+	}}
+	tenaryProp={ 1 + 1 === 2 ? t`True` : t`False` }
+/>
 
 {#if loggedIn}
 	<button>{t`Log out`}</button>


### PR DESCRIPTION
## Problem

Given Svelte component like this:
```svelte
<svelte:component
	this={false}
	objExpressionProp={{
		title: t`Title in obj`,
	}}
	tenaryProp={ 1 + 1 === 2 ? t`True` : t`False` }
/>
```
Currently, `ttag extract` will fail on babel syntax error.

Another thing is, we ignored [`<script context="module">`](https://svelte.dev/docs#script_context_module) when extracting strings.

## Root cause
Currently svelte template expressions (`{...}`) are extracted and put in a string directly, then we send the whole string as code to babel to do transformation.

However, the expressions above will be extracted as:
```javascript
false
{
  title: t`Title in obj`,
}
1 + 1 === 2 ? t`True` : t`False`
```
The `{` are parsed as the start of a scope, and `title:` is parsed as a [Javascript label statement](https://developer.mozilla.org/docs/Web/JavaScript/Reference/Statements/label), thus `t` following the labeled text triggers syntax errors.

## Proposed solution
For each extracted template expression, we wrap `( );` around each expression to make sure that expressions are interpreted as expressions by babel.
```javascript
(false);
({
  title: t`Title in obj`,
});
(1 + 1 === 2 ? t`True` : t`False`);
```


When extracting scripts, we should also handle `<script context="module">` scripts.