### PR TITLE
Apply loose to preset-env to silence warning

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -31,7 +31,7 @@ export const defaultPresets: ConfigItem[] = [
     presetTS,
     presetConstEnumTS,
     presetFlow,
-    presetEnv,
+    [presetEnv, { loose: true }],
     presetReact
 ];
 


### PR DESCRIPTION
When executing ttag-cli on my source I get many warnings like these:

```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-property-in-object since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
        ["@babel/plugin-proposal-private-property-in-object", { "loose": true }]
to the "plugins" section of your Babel config.
```

This change removes the warning and seems to have no negative effect.