### PR TITLE
Support gettext-parser's foldLength option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ will update existing po file. Add/remove new translations
 	--numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.
 	--extractLocation   string - 'full' | 'file' | 'never' - https://ttag.js.org/docs/plugin-api.html#configextractlocation. Is used to format location comments in the .po file.
 	--sortByMsgid boolean. Will sort output in alphabetically by msgid. https://ttag.js.org/docs/plugin-api.html#configsortbymsgid
-
+	--foldLength   number. Output .po file line width.
 
 ### `replace [options] <pofile> <out> <path>`
 will replace all strings with translations from the .po file

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -4,14 +4,15 @@ import * as fs from "fs";
 import { extractAll } from "../lib/extract";
 import { updatePo } from "../lib/update";
 import { parse } from "../lib/parser";
-import { serialize } from "../lib/serializer";
+import { serialize, SerializeOptions } from "../lib/serializer";
 
 async function update(
     pofile: string,
     src: string[],
     lang: string,
     ttagOverrideOpts?: ttagTypes.TtagOpts,
-    ttagRcOpts?: ttagTypes.TtagRc
+    ttagRcOpts?: ttagTypes.TtagRc,
+    serializeOpts?: SerializeOptions
 ) {
     const progress: ttagTypes.Progress = ora(`[ttag] updating ${pofile} ...`);
     progress.start();
@@ -21,7 +22,7 @@ async function update(
         );
         const po = parse(fs.readFileSync(pofile).toString());
         const resultPo = updatePo(pot, po);
-        fs.writeFileSync(pofile, serialize(resultPo));
+        fs.writeFileSync(pofile, serialize(resultPo, serializeOpts));
         progress.succeed(`${pofile} updated`);
     } catch (err) {
         progress.fail(`Failed to update. ${err.message}. ${err.stack}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,7 +222,11 @@ yargs
             src: {
                 description: "path to source files/directories"
             },
-            ...getTtagOptsForYargs()
+            ...getTtagOptsForYargs(),
+            foldLength: {
+                description: "line width in .po file",
+                number: true
+            }
         },
         argv => {
             update(
@@ -230,7 +234,10 @@ yargs
                 argv.src,
                 argv.lang,
                 parseTtagPluginOpts(argv),
-                parseTtagRcOpts()
+                parseTtagRcOpts(),
+                {
+                    foldLength: argv.foldLength
+                }
             );
         }
     )

--- a/src/lib/serializer.ts
+++ b/src/lib/serializer.ts
@@ -1,6 +1,10 @@
 import { po } from "gettext-parser";
 import { PoData } from "../lib/parser";
 
-export function serialize(poData: PoData): Buffer {
-    return po.compile(poData);
+export type SerializeOptions = {
+    foldLength?: number;
+};
+
+export function serialize(poData: PoData, options?: SerializeOptions): Buffer {
+    return po.compile(poData, options);
 }


### PR DESCRIPTION
https://github.com/smhg/gettext-parser#compile-po-from-a-translation-object

Please advise on style and where this should belong! I didn't implement the other two options because one is already implemented the babel plugin and the other seems to be detrimental.