### PR TITLE
Skip fully filled translations for translation cmd

### DIFF
--- a/src/commands/translate.ts
+++ b/src/commands/translate.ts
@@ -16,7 +16,9 @@ export function* untranslatedStream(translations: Translations): any {
         const context = translations[contextKey];
         for (const msgid of Object.keys(context)) {
             const msg = context[msgid];
-            msg.msgstr = yield [contextKey, msg];
+            if (msg.msgstr.includes("") || !msgid) {
+                msg.msgstr = yield [contextKey, msg];
+            }
         }
     }
 }

--- a/tests/commands/__snapshots__/test_translate.ts.snap
+++ b/tests/commands/__snapshots__/test_translate.ts.snap
@@ -15,5 +15,18 @@ msgid \\"test_plural\\"
 msgid_plural \\"test_plural\\"
 msgstr[0] \\"test1\\"
 msgstr[1] \\"test2\\"
+
+msgid \\"filled_test\\"
+msgstr \\"filled value\\"
+
+msgid \\"partially_filled_test_plural\\"
+msgid_plural \\"test_plural\\"
+msgstr[0] \\"overwritten test1\\"
+msgstr[1] \\"overwritten test2\\"
+
+msgid \\"fully_filled_test_plural\\"
+msgid_plural \\"test_plural\\"
+msgstr[0] \\"filled value\\"
+msgstr[1] \\"filled values\\"
 "
 `;

--- a/tests/commands/test_translate.ts
+++ b/tests/commands/test_translate.ts
@@ -15,6 +15,7 @@ test("translate poFile", () => {
     stream.next("");
     stream.next(["test"]);
     stream.next(["test1", "test2"]);
+    stream.next(["overwritten test1", "overwritten test2"]);
     const data = serialize(poData).toString();
     expect(data).toMatchSnapshot();
 });

--- a/tests/fixtures/translateTest/translate.po
+++ b/tests/fixtures/translateTest/translate.po
@@ -12,3 +12,16 @@ msgid "test_plural"
 msgid_plural "test_plural"
 msgstr[0] ""
 msgstr[1] ""
+
+msgid "filled_test"
+msgstr "filled value"
+
+msgid "partially_filled_test_plural"
+msgid_plural "test_plural"
+msgstr[0] "filled value"
+msgstr[1] ""
+
+msgid "fully_filled_test_plural"
+msgid_plural "test_plural"
+msgstr[0] "filled value"
+msgstr[1] "filled values"


### PR DESCRIPTION
Hi, I try to fix [that issue ](https://github.com/ttag-org/ttag-cli/issues/135) about translation command.
Tests passed, and I add 0 breaking change,I just fix according to the documentation.

I tried to keep it simple but feel free to ask me to do some refacto if you think that it would be better