### PR TITLE
support exclude argv for ttag-cli extract function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ will extract translations to .pot file
 	--numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.  
 	--extractLocation   string - 'full' | 'file' | 'never' - https://ttag.js.org/docs/plugin-api.html#configextractlocation. Is used to format location comments in the .po file.
 	--sortByMsgid boolean. Will sort output in alphabetically by msgid. https://ttag.js.org/docs/plugin-api.html#configsortbymsgid
-
+  --exclude  -e   exclude files or directories matching the given glob pattern(s) from extraction
 
 ### `check [lang] <pofile> <src...>`
 will check if all translations are present in .po file

--- a/src/commands/extract.ts
+++ b/src/commands/extract.ts
@@ -8,18 +8,23 @@ async function extract(
     paths: string[],
     lang: string = "en",
     ttagOverrideOpts?: c3poTypes.TtagOpts,
-    ttagRcOpts?: c3poTypes.TtagRc
+    ttagRcOpts?: c3poTypes.TtagRc,
+    exclude?: string[]
 ) {
     const progress: c3poTypes.Progress = ora(
         `[ttag] extracting translations to ${output} ...`
     );
     progress.start();
+
+    const excludeRegexp = exclude ? new RegExp(exclude.join("|")) : undefined;
+
     const result = await extractAll(
         paths,
         lang,
         progress,
         ttagOverrideOpts,
-        ttagRcOpts
+        ttagRcOpts,
+        excludeRegexp
     );
     fs.writeFileSync(output, result);
     progress.succeed(`[ttag] translations extracted to ${output}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,11 @@ yargs
                 default: "en",
                 description: "sets default lang (ISO format)"
             },
+            exclude: {
+                alias: "e",
+                type: "array",
+                description: "exclude files or directories from extraction"
+            },
             ...getTtagOptsForYargs()
         },
         argv => {
@@ -92,7 +97,8 @@ yargs
                 argv.src,
                 argv.lang,
                 parseTtagPluginOpts(argv),
-                parseTtagRcOpts()
+                parseTtagRcOpts(),
+                argv.exclude // pass the exclude option value to the extract function
             );
         }
     )

--- a/src/lib/extract.ts
+++ b/src/lib/extract.ts
@@ -18,7 +18,8 @@ export async function extractAll(
     lang: string,
     progress: ttagTypes.Progress,
     overrideOpts?: ttagTypes.TtagOpts,
-    rcOpts?: ttagTypes.TtagRc
+    rcOpts?: ttagTypes.TtagRc,
+    excludeRegexp?: RegExp
 ): Promise<string> {
     const tmpFile = tmp.fileSync();
     let ttagOpts: ttagTypes.TtagOpts = {
@@ -34,6 +35,11 @@ export async function extractAll(
     }
     const babelOptions = makeBabelConf(ttagOpts);
     const transformFn: TransformFn = filepath => {
+        // exclude paths
+        if (excludeRegexp && excludeRegexp.test(filepath)) {
+            return;
+        }
+
         try {
             switch (extname(filepath)) {
                 case ".vue": {
@@ -116,9 +122,9 @@ export async function extractAll(
             }
             progress.fail("Failed to extract translations");
             process.exit(1);
-            return;
         }
     };
+
     await pathsWalk(
         getWalkingPaths(paths, rcOpts),
         progress,

--- a/tests/commands/__snapshots__/test_extract.ts.snap
+++ b/tests/commands/__snapshots__/test_extract.ts.snap
@@ -179,6 +179,49 @@ msgstr \\"\\"
 "
 `;
 
+exports[`extract with e alias 1`] = `
+"msgid \\"\\"
+msgstr \\"\\"
+\\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+\\"Plural-Forms: nplurals=2; plural=(n!=1);\\\\n\\"
+
+#: tests/fixtures/extractExcludeTest/test1.js:4
+#, javascript-format
+msgid \\"test translation \${ name }\\"
+msgstr \\"\\"
+"
+`;
+
+exports[`extract with exclude by regexp 1`] = `
+"msgid \\"\\"
+msgstr \\"\\"
+\\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+\\"Plural-Forms: nplurals=2; plural=(n!=1);\\\\n\\"
+
+#: tests/fixtures/extractExcludeTest/test1.js:4
+#, javascript-format
+msgid \\"test translation \${ name }\\"
+msgstr \\"\\"
+"
+`;
+
+exports[`extract with excludePaths 1`] = `
+"msgid \\"\\"
+msgstr \\"\\"
+\\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+\\"Plural-Forms: nplurals=2; plural=(n!=1);\\\\n\\"
+
+#: tests/fixtures/extractExcludeTest/test1.js:4
+#, javascript-format
+msgid \\"test translation \${ name }\\"
+msgstr \\"\\"
+
+#: tests/fixtures/extractExcludeTest/excluded/test2.js:4
+msgid \\"test translation 2 \${ name }\\"
+msgstr \\"\\"
+"
+`;
+
 exports[`should extract in the alphabetical order (sortByMsgid) 1`] = `
 "msgid \\"\\"
 msgstr \\"\\"

--- a/tests/commands/test_extract.ts
+++ b/tests/commands/test_extract.ts
@@ -17,6 +17,10 @@ const sveltePath = path.resolve(
     __dirname,
     "../fixtures/testSvelteParse.svelte"
 );
+const extractExcludePath = path.resolve(
+    __dirname,
+    "../fixtures/extractExcludeTest"
+);
 const globalFn = path.resolve(__dirname, "../fixtures/globalFunc.js");
 const tsPath = path.resolve(__dirname, "../fixtures/tSParse.ts");
 const tsChaning = path.resolve(__dirname, "../fixtures/tsOptionalChaning.ts");
@@ -129,6 +133,30 @@ test("extract from ts", () => {
 
 test("extract from ts with const enum", () => {
     execSync(`ts-node src/index.ts extract -o ${potPath} ${tsConstEnum}`);
+    const result = fs.readFileSync(potPath).toString();
+    expect(result).toMatchSnapshot();
+});
+
+test("extract with excludePaths", () => {
+    execSync(
+        `ts-node src/index.ts extract --exclude="nested" -o ${potPath} ${extractExcludePath}`
+    );
+    const result = fs.readFileSync(potPath).toString();
+    expect(result).toMatchSnapshot();
+});
+
+test("extract with exclude by regexp", () => {
+    execSync(
+        `ts-node src/index.ts extract --exclude="nested|excluded" -o ${potPath} ${extractExcludePath}`
+    );
+    const result = fs.readFileSync(potPath).toString();
+    expect(result).toMatchSnapshot();
+});
+
+test("extract with e alias", () => {
+    execSync(
+        `ts-node src/index.ts extract -e "nested" "excluded" -o ${potPath} ${extractExcludePath}`
+    );
     const result = fs.readFileSync(potPath).toString();
     expect(result).toMatchSnapshot();
 });

--- a/tests/fixtures/extractExcludeTest/excluded/nested/test2.js
+++ b/tests/fixtures/extractExcludeTest/excluded/nested/test2.js
@@ -1,0 +1,4 @@
+import { t, c } from 'ttag';
+
+const name = 'Mike';
+t`test translation 2 ${name}`;

--- a/tests/fixtures/extractExcludeTest/excluded/test2.js
+++ b/tests/fixtures/extractExcludeTest/excluded/test2.js
@@ -1,0 +1,4 @@
+import { t, c } from 'ttag';
+
+const name = 'Mike';
+t`test translation 2 ${name}`;

--- a/tests/fixtures/extractExcludeTest/nested/test2.js
+++ b/tests/fixtures/extractExcludeTest/nested/test2.js
@@ -1,0 +1,4 @@
+import { t, c } from 'ttag';
+
+const name = 'Mike';
+t`test translation 2 ${name}`;

--- a/tests/fixtures/extractExcludeTest/test.xml
+++ b/tests/fixtures/extractExcludeTest/test.xml
@@ -1,0 +1,3 @@
+<test>
+<shouldnottransform/>
+</test>

--- a/tests/fixtures/extractExcludeTest/test1.js
+++ b/tests/fixtures/extractExcludeTest/test1.js
@@ -1,0 +1,4 @@
+import { t } from 'ttag';
+
+const name = 'Mike';
+t`test translation ${name}`;


### PR DESCRIPTION
### Description

This PR adds a new exclude option to the extract command in ttag-cli, allowing users to exclude specific files or directories from the extraction process. The exclude option takes an array of strings, which can be either file or directory paths to exclude.

The implementation includes a new `--exclude` or `-e` flag in the yargs configuration object, which passes the value of argv.exclude to the extract function. The function then uses this array to exclude the specified files and directories from the extraction process.

### Changes Made

Added a new exclude option to the extract command in ttag-cli
Implemented the `--exclude` or `-e` flag in the yargs configuration object
Passed the argv.exclude value to the extract function to exclude specified files and directories from the extraction process


### Checklist
 - [ ] I have tested this code
 - [ ] I have updated the documentation
 - [ ] I have added appropriate tests
