### PR TITLE
Parse `<template>` in "vue" files

### DIFF
--- a/src/lib/extract.ts
+++ b/src/lib/extract.ts
@@ -38,6 +38,19 @@ export async function extractAll(
             switch (extname(filepath)) {
                 case ".vue": {
                     const source = fs.readFileSync(filepath).toString();
+                    const template = parseComponent(source).template;
+                    if (template) {
+                        const lineCount =
+                            source.slice(0, template.start).split(/\r\n|\r|\n/)
+                                .length - 1;
+                        babel.transformSync(
+                            "\n".repeat(lineCount) + template.content,
+                            {
+                                filename: filepath,
+                                ...babelOptions
+                            }
+                        );
+                    }
                     const script = parseComponent(source).script;
                     if (script) {
                         const lineCount =

--- a/tests/commands/__snapshots__/test_extract.ts.snap
+++ b/tests/commands/__snapshots__/test_extract.ts.snap
@@ -161,6 +161,12 @@ msgstr \\"\\"
 \\"Content-Type: text/plain; charset=utf-8\\\\n\\"
 \\"Plural-Forms: nplurals=2; plural=(n!=1);\\\\n\\"
 
+#: tests/fixtures/vueTest/testVueParse.vue:2
+msgid \\"test from vue file (template)\\"
+msgstr \\"\\"
+"
+`;
+
 #: tests/fixtures/vueTest/testVueParse.vue:10
 msgid \\"test from vue file\\"
 msgstr \\"\\"

--- a/tests/fixtures/vueTest/testVueParse.vue
+++ b/tests/fixtures/vueTest/testVueParse.vue
@@ -1,5 +1,5 @@
 <template>
-    <h1>Hello World</h1>
+    <h1>{{ t`test from vue file (template)` }}</h1>
 </template>
 <script>
 import { t } from "ttag";


### PR DESCRIPTION
This provides the parse of `<template>` in `.vue` files, as asked in https://github.com/ttag-org/ttag/issues/201