### PR TITLE
make isFuzzy return true if tag string includes "fuzzy"

### DIFF
--- a/src/commands/filter.ts
+++ b/src/commands/filter.ts
@@ -19,7 +19,7 @@ function FuzzyTest(msg: Message): boolean {
     if (msg.comments == undefined) {
         return false;
     }
-    return msg.comments.flag == "fuzzy";
+    return msg.comments.flag && msg.comments.flag.includes("fuzzy");
 }
 
 function TranslatedTest(msg: Message): boolean {


### PR DESCRIPTION
When there are multiple flags, like `#, fuzzy, javascript-format`, still detect that it is fuzzy

equivalent to:

https://github.com/ttag-org/babel-plugin-ttag/pull/179/commits/0c8d53641ba4e3999e3b20d416881518d8771859