### PR TITLE
Add support for .mjs, .cjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 > Some of the talks, presentations, and documentation _may_ reference it with both names.
 
 Command line utility for [ttag](https://github.com/ttag-org/ttag) translation library.
-Works out of the box with **js**, **ts**, **jsx**, **tsx**, **vue**, **svelte**,  files.
+Works out of the box with **js**, **ts**, **jsx**, **tsx**, **mjs**, **cjs**, **vue**, **svelte**,  files.
 
 # Installation
 ```bash

--- a/src/lib/pathsWalk.ts
+++ b/src/lib/pathsWalk.ts
@@ -16,6 +16,8 @@ function walkFile(
         extname === ".jsx" ||
         extname === ".ts" ||
         extname === ".tsx" ||
+        extname === ".mjs" ||
+        extname === ".cjs" ||
         extname === ".vue" ||
         extname === ".svelte"
     ) {


### PR DESCRIPTION
Node's module system is in transition from CommonJS to ECMA Script. If you don't use typescript and want both systems, .cjs/.mjs is the way to go.