### PR TITLE
Isolate babel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,22 +26,25 @@ ttag extract some.js
 ### `extract [output|lang] <src...>`
 will extract translations to .pot file
 #### Arguments:
-	--output  -o   result file with translations (.pot)  (default: translations.pot)
-	--lang  -l   sets default lang (ISO format)  (default: en)
-	--discover   string overrides babel-plugi-ttag setting - https://ttag.js.org/docs/plugin-api.html#configdiscover. Can be used to discover ttag functions without explicit import.    Only known ttag functions can be used as params (t, jt, ngettext, gettext, _)  
-	--numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.  
-	--extractLocation   string - 'full' | 'file' | 'never' - https://ttag.js.org/docs/plugin-api.html#configextractlocation. Is used to format location comments in the .po file.
-	--sortByMsgid boolean. Will sort output in alphabetically by msgid. https://ttag.js.org/docs/plugin-api.html#configsortbymsgid
+	-output  --o   result file with translations (.pot)  (default: translations.pot)
+	-lang  --l   sets default lang (ISO format)  (default: en)
+	-discover   string overrides babel-plugi-ttag setting - https://ttag.js.org/docs/plugin-api.html#configdiscover. Can be used to discover ttag functions without explicit import.    Only known ttag functions can be used as params (t, jt, ngettext, gettext, _)  
+	-numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.  
+	-extractLocation   string - 'full' | 'file' | 'never' - https://ttag.js.org/docs/plugin-api.html#configextractlocation. Is used to format location comments in the .po file.   
+	-sortByMsgid   boolean - The resulting output will be sorted alphabetically. https://ttag.js.org/docs/plugin-api.html#configsortbymsgid  
+	-useProjectBabelrc   boolean - Ttag cli will use projects babel config files. https://ttag.js.org/docs/plugin-api.html#useProjectBabelrcDescription  
 
 
 ### `check [lang] <pofile> <src...>`
 will check if all translations are present in .po file
 #### Arguments:
-	--lang  -l   sets default lang (ISO format)  (default: en)
-	--skip	allows you to skip some instances of validation. This can be useful when you want to check your .po file for duplicate keys
-		[choices: "translation"]
-	--discover   string overrides babel-plugi-ttag setting - https://ttag.js.org/docs/plugin-api.html#configdiscover. Can be used to discover ttag functions without explicit import.    Only known ttag functions can be used as params (t, jt, ngettext, gettext, _)  
-	--numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.  
+	-lang  --l   sets default lang (ISO format)  (default: en)
+	-skip   let skip translation check  
+	-discover   string overrides babel-plugi-ttag setting - https://ttag.js.org/docs/plugin-api.html#configdiscover. Can be used to discover ttag functions without explicit import.    Only known ttag functions can be used as params (t, jt, ngettext, gettext, _)  
+	-numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.  
+	-extractLocation   string - 'full' | 'file' | 'never' - https://ttag.js.org/docs/plugin-api.html#configextractlocation. Is used to format location comments in the .po file.   
+	-sortByMsgid   boolean - The resulting output will be sorted alphabetically. https://ttag.js.org/docs/plugin-api.html#configsortbymsgid  
+	-useProjectBabelrc   boolean - Ttag cli will use projects babel config files. https://ttag.js.org/docs/plugin-api.html#useProjectBabelrcDescription  
 
 
 ### `merge <path...>`
@@ -51,7 +54,7 @@ will merge two or more po(t) files together using first non-empty msgstr and hea
 ### `translate <path> [args]`
 will open interactive prompt to translate all msgids with empty msgstr in cli
 #### Arguments:
-	--output  -o   result file with translations (.po)  (default: translated.po)
+	-output  --o   result file with translations (.po)  (default: translated.po)
 
 
 ### `stats <path>`
@@ -61,11 +64,11 @@ will display various pofile statistics(encoding, plurals, translated, fuzzyness)
 ### `filter <path> [args]`
 will filter pofile by entry attributes(fuzzy, obsolete, (un)translated)
 #### Arguments:
-	--fuzzy  -f   result file with fuzzy messages (.po)  (default: false)
-	--no-fuzzy  -nf   result file without fuzzy messages (.po)  (default: false)
-	--translated  -t   result file with translations (.po)  (default: false)
-	--not-translated  -nt   result file without translations (.po)  (default: false)
-	--reference  -r   a regexp to match references against  (default: )
+	-fuzzy  --f   result file with fuzzy messages (.po)  (default: false)
+	-no-fuzzy  --nf   result file without fuzzy messages (.po)  (default: false)
+	-translated  --t   result file with translations (.po)  (default: false)
+	-not-translated  --nt   result file without translations (.po)  (default: false)
+	-reference  --r   a regexp to match references against  (default: )
 #### Example:
 	 ttag filter -nt small.po
 
@@ -75,31 +78,42 @@ will filter pofile by entry attributes(fuzzy, obsolete, (un)translated)
 ### `init <lang> <filename>`
 will create an empty .po file with all necessary headers for the locale
 #### Arguments:
-	--lang   sets default locale (ISO format)  (default: en)
-	--filename   path to the .po file  
+	-lang   sets default locale (ISO format)  (default: en)
+	-filename   path to the .po file  
 
 
 ### `update [opts] <pofile> <src..>`
 will update existing po file. Add/remove new translations
 #### Arguments:
-	--lang   sets default locale (ISO format)  (default: en)
-	--pofile   path to .po file with translations  
-	--src   path to source files/directories  
-	--discover   string overrides babel-plugi-ttag setting - https://ttag.js.org/docs/plugin-api.html#configdiscover. Can be used to discover ttag functions without explicit import.    Only known ttag functions can be used as params (t, jt, ngettext, gettext, _)  
-	--numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.
-	--extractLocation   string - 'full' | 'file' | 'never' - https://ttag.js.org/docs/plugin-api.html#configextractlocation. Is used to format location comments in the .po file.
-	--sortByMsgid boolean. Will sort output in alphabetically by msgid. https://ttag.js.org/docs/plugin-api.html#configsortbymsgid
-	--foldLength   number. Output .po file line width.
+	-lang   sets default locale (ISO format)  (default: en)
+	-pofile   path to .po file with translations  
+	-src   path to source files/directories  
+	-discover   string overrides babel-plugi-ttag setting - https://ttag.js.org/docs/plugin-api.html#configdiscover. Can be used to discover ttag functions without explicit import.    Only known ttag functions can be used as params (t, jt, ngettext, gettext, _)  
+	-numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.  
+	-extractLocation   string - 'full' | 'file' | 'never' - https://ttag.js.org/docs/plugin-api.html#configextractlocation. Is used to format location comments in the .po file.   
+	-sortByMsgid   boolean - The resulting output will be sorted alphabetically. https://ttag.js.org/docs/plugin-api.html#configsortbymsgid  
+	-useProjectBabelrc   boolean - Ttag cli will use projects babel config files. https://ttag.js.org/docs/plugin-api.html#useProjectBabelrcDescription  
+	-foldLength   line width in .po file  
+
 
 ### `replace [options] <pofile> <out> <path>`
 will replace all strings with translations from the .po file
 #### Arguments:
-	--discover   string overrides babel-plugi-ttag setting - https://ttag.js.org/docs/plugin-api.html#configdiscover. Can be used to discover ttag functions without explicit import.    Only known ttag functions can be used as params (t, jt, ngettext, gettext, _)  
-	--numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.  
+	-discover   string overrides babel-plugi-ttag setting - https://ttag.js.org/docs/plugin-api.html#configdiscover. Can be used to discover ttag functions without explicit import.    Only known ttag functions can be used as params (t, jt, ngettext, gettext, _)  
+	-numberedExpressions   boolean overrides babel-plugin-ttag setting -  https://ttag.js.org/docs/plugin-api.html#confignumberedexpressions. Refer to the doc for the details.  
+	-extractLocation   string - 'full' | 'file' | 'never' - https://ttag.js.org/docs/plugin-api.html#configextractlocation. Is used to format location comments in the .po file.   
+	-sortByMsgid   boolean - The resulting output will be sorted alphabetically. https://ttag.js.org/docs/plugin-api.html#configsortbymsgid  
+	-useProjectBabelrc   boolean - Ttag cli will use projects babel config files. https://ttag.js.org/docs/plugin-api.html#useProjectBabelrcDescription  
 
 
 ### `color <pofile>`
 will output po(t)file with pretty colors on, combine with | less -r
+
+
+### `pseudo <path> [args]`
+will output a pseudo-localised translation
+#### Arguments:
+	-output  --o   result file with pseudo translations (.po)  (default: pseudo.po)
 
 
 ### `spell <pofile> [locale]`
@@ -117,10 +131,9 @@ will open pofile in web editor
 ### `po2json <pofile> [args]`
 will parse and output po file as loadable JSON
 #### Arguments:
-	--pretty  -p   pretty print js  (default: false)
-	--nostrip  --n   do not strip comments/headers  (default: false)
-	--format  sets the output JSON format (compact is much smaller)
-        [choices: "compact", "verbose"] [default: "verbose"]
+	-pretty  --p   pretty print js  (default: false)
+	-nostrip  --n   do not strip comments/headers  (default: false)
+	-format   sets the output JSON format (compact is much smaller)  (default: verbose)
 
 
 <!--- END COMMANDS --->

--- a/package-lock.json
+++ b/package-lock.json
@@ -71,6 +71,7 @@
         "@types/walk": "^2.3.0",
         "@types/yargs": "8.0.2",
         "babel-core": "^7.0.0-bridge.0",
+        "babel-plugin-react-compiler": "^19.1.0-rc.2",
         "husky": "^0.14.3",
         "jest": "^24.9.0",
         "lint-staged": "^5.0.0",
@@ -190,16 +191,6 @@
         "lodash": "^4.17.19"
       }
     },
-    "node_modules/@babel/core/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/core/node_modules/convert-source-map": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -248,32 +239,12 @@
         "source-map": "^0.5.0"
       }
     },
-    "node_modules/@babel/generator/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-annotate-as-pure": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.10.4.tgz",
       "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
       "dependencies": {
         "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -283,16 +254,6 @@
       "dependencies": {
         "@babel/helper-explode-assignable-expression": "^7.10.4",
         "@babel/types": "^7.10.4"
-      }
-    },
-    "node_modules/@babel/helper-builder-binary-assignment-operator-visitor/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-builder-react-jsx": {
@@ -312,26 +273,6 @@
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-module-imports": "^7.12.1",
         "@babel/types": "^7.12.1"
-      }
-    },
-    "node_modules/@babel/helper-builder-react-jsx-experimental/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
-    "node_modules/@babel/helper-builder-react-jsx/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
@@ -383,16 +324,6 @@
         "@babel/types": "^7.11.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-create-regexp-features-plugin": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-create-regexp-features-plugin/-/helper-create-regexp-features-plugin-7.12.1.tgz",
@@ -431,32 +362,12 @@
         "@babel/types": "^7.10.4"
       }
     },
-    "node_modules/@babel/helper-define-map/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-explode-assignable-expression": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-explode-assignable-expression/-/helper-explode-assignable-expression-7.12.1.tgz",
       "integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
       "dependencies": {
         "@babel/types": "^7.12.1"
-      }
-    },
-    "node_modules/@babel/helper-explode-assignable-expression/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
@@ -487,16 +398,6 @@
         "@babel/types": "^7.10.4"
       }
     },
-    "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
@@ -505,32 +406,12 @@
         "@babel/types": "^7.12.1"
       }
     },
-    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.12.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz",
       "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
       "dependencies": {
         "@babel/types": "^7.12.5"
-      }
-    },
-    "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
@@ -620,16 +501,6 @@
         "lodash": "^4.17.19"
       }
     },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-module-transforms/node_modules/debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -654,16 +525,6 @@
         "@babel/types": "^7.10.4"
       }
     },
-    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0.tgz",
@@ -685,16 +546,6 @@
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-wrap-function": "^7.10.4",
         "@babel/types": "^7.12.1"
-      }
-    },
-    "node_modules/@babel/helper-remap-async-to-generator/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-replace-supers": {
@@ -779,16 +630,6 @@
         "lodash": "^4.17.19"
       }
     },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-replace-supers/node_modules/debug": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -813,32 +654,12 @@
         "@babel/types": "^7.12.1"
       }
     },
-    "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz",
       "integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
       "dependencies": {
         "@babel/types": "^7.12.1"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-split-export-declaration": {
@@ -850,21 +671,23 @@
         "@babel/types": "^7.4.4"
       }
     },
-    "node_modules/@babel/helper-split-export-declaration/node_modules/@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
-        "to-fast-properties": "^2.0.0"
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.12.1",
@@ -951,16 +774,6 @@
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/helper-wrap-function/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helper-wrap-function/node_modules/debug": {
@@ -1058,16 +871,6 @@
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.19"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/helpers/node_modules/debug": {
@@ -1634,16 +1437,6 @@
         "@babel/types": "^7.11.0"
       }
     },
-    "node_modules/@babel/plugin-transform-classes/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-computed-properties": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz",
@@ -1769,16 +1562,6 @@
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
       "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
     },
     "node_modules/@babel/plugin-transform-literals": {
       "version": "7.12.1",
@@ -2233,16 +2016,6 @@
         "@babel/highlight": "^7.0.0"
       }
     },
-    "node_modules/@babel/plugin-transform-typescript/node_modules/@babel/types": {
-      "version": "7.7.1",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
-      "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
-      "dependencies": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-typescript/node_modules/debug": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -2387,16 +2160,6 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
-    "node_modules/@babel/preset-env/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/preset-flow": {
       "version": "7.12.1",
       "resolved": "https://registry.npmjs.org/@babel/preset-flow/-/preset-flow-7.12.1.tgz",
@@ -2421,16 +2184,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      }
-    },
-    "node_modules/@babel/preset-modules/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/preset-react": {
@@ -2511,16 +2264,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@babel/template/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
     "node_modules/@babel/traverse": {
       "version": "7.4.5",
       "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.5.tgz",
@@ -2536,17 +2279,6 @@
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.11"
-      }
-    },
-    "node_modules/@babel/traverse/node_modules/@babel/types": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-      "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.11",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@babel/traverse/node_modules/debug": {
@@ -2565,14 +2297,16 @@
       "dev": true
     },
     "node_modules/@babel/types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
-      "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
-      "dev": true,
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
+      "license": "MIT",
       "dependencies": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@cnakazawa/watch": {
@@ -2953,17 +2687,6 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.3.0"
-      }
-    },
-    "node_modules/@types/babel__traverse/node_modules/@babel/types": {
-      "version": "7.12.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-      "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -3732,6 +3455,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/babel-plugin-react-compiler": {
+      "version": "19.1.0-rc.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.1.0-rc.2.tgz",
+      "integrity": "sha512-kSNA//p5fMO6ypG8EkEVPIqAjwIXm5tMjfD1XRPL/sRjYSbJ6UsvORfaeolNWnZ9n310aM0xJP7peW26BuCVzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.26.0"
+      }
+    },
     "node_modules/babel-plugin-ttag": {
       "version": "1.8.16",
       "resolved": "https://registry.npmjs.org/babel-plugin-ttag/-/babel-plugin-ttag-1.8.16.tgz",
@@ -3746,21 +3479,6 @@
         "gettext-parser": "6.0.0",
         "mkdirp": "^1.0.4",
         "plural-forms": "^0.5.3"
-      }
-    },
-    "node_modules/babel-plugin-ttag/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-    },
-    "node_modules/babel-plugin-ttag/node_modules/@babel/types": {
-      "version": "7.12.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-      "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/babel-plugin-ttag/node_modules/babel-plugin-macros": {
@@ -6246,17 +5964,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/istanbul-lib-instrument/node_modules/@babel/types": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-      "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.10.4",
-        "lodash": "^4.17.19",
-        "to-fast-properties": "^2.0.0"
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
@@ -10665,14 +10372,6 @@
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
-    "node_modules/to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
@@ -11812,16 +11511,6 @@
             "lodash": "^4.17.19"
           }
         },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "convert-source-map": {
           "version": "1.7.0",
           "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -11861,18 +11550,6 @@
         "@babel/types": "^7.12.5",
         "jsesc": "^2.5.1",
         "source-map": "^0.5.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-annotate-as-pure": {
@@ -11881,18 +11558,6 @@
       "integrity": "sha512-XQlqKQP4vXFB7BN8fEEerrmYvHp3fK/rBkRFz9jaJbzK0B1DSfej9Kc7ZzE8Z/OnId1jpJdNAZ3BFQjWG68rcA==",
       "requires": {
         "@babel/types": "^7.10.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -11902,18 +11567,6 @@
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.10.4",
         "@babel/types": "^7.10.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-builder-react-jsx": {
@@ -11923,18 +11576,6 @@
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/types": "^7.10.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-builder-react-jsx-experimental": {
@@ -11945,18 +11586,6 @@
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-module-imports": "^7.12.1",
         "@babel/types": "^7.12.1"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-compilation-targets": {
@@ -12007,16 +11636,6 @@
           "requires": {
             "@babel/types": "^7.11.0"
           }
-        },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -12057,16 +11676,6 @@
           "requires": {
             "@babel/types": "^7.10.4"
           }
-        },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -12076,18 +11685,6 @@
       "integrity": "sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==",
       "requires": {
         "@babel/types": "^7.12.1"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-function-name": {
@@ -12116,18 +11713,6 @@
       "integrity": "sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==",
       "requires": {
         "@babel/types": "^7.10.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -12136,18 +11721,6 @@
       "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
       "requires": {
         "@babel/types": "^7.12.1"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-module-imports": {
@@ -12156,18 +11729,6 @@
       "integrity": "sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==",
       "requires": {
         "@babel/types": "^7.12.5"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-module-transforms": {
@@ -12251,16 +11812,6 @@
             "lodash": "^4.17.19"
           }
         },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -12282,18 +11833,6 @@
       "integrity": "sha512-n3UGKY4VXwXThEiKrgRAoVPBMqeoPgHVqiHZOanAJCG9nQUL2pLRQirUzl0ioKclHGpGqRgIOkgcIJaIWLpygg==",
       "requires": {
         "@babel/types": "^7.10.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-plugin-utils": {
@@ -12317,18 +11856,6 @@
         "@babel/helper-annotate-as-pure": "^7.10.4",
         "@babel/helper-wrap-function": "^7.10.4",
         "@babel/types": "^7.12.1"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-replace-supers": {
@@ -12407,16 +11934,6 @@
             "lodash": "^4.17.19"
           }
         },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
@@ -12438,18 +11955,6 @@
       "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
       "requires": {
         "@babel/types": "^7.12.1"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -12458,18 +11963,6 @@
       "integrity": "sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==",
       "requires": {
         "@babel/types": "^7.12.1"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -12479,25 +11972,17 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.4.4"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
+    "@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="
+    },
     "@babel/helper-validator-identifier": {
-      "version": "7.10.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
-      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow=="
     },
     "@babel/helper-validator-option": {
       "version": "7.12.1",
@@ -12578,16 +12063,6 @@
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.19"
-          }
-        },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
@@ -12678,16 +12153,6 @@
             "debug": "^4.1.0",
             "globals": "^11.1.0",
             "lodash": "^4.17.19"
-          }
-        },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
@@ -13307,16 +12772,6 @@
           "requires": {
             "@babel/types": "^7.11.0"
           }
-        },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -13459,16 +12914,6 @@
           "version": "7.10.4",
           "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz",
           "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
-        },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -13965,16 +13410,6 @@
             }
           }
         },
-        "@babel/types": {
-          "version": "7.7.1",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.1.tgz",
-          "integrity": "sha512-kN/XdANDab9x1z5gcjDc9ePpxexkt+1EQ2MQUiM4XnMvQfvp87/+6kY4Ko2maLXH+tei/DgJ/ybFITeqqRwDiA==",
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.13",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -14124,16 +13559,6 @@
           "requires": {
             "@babel/helper-plugin-utils": "^7.8.0"
           }
-        },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -14163,18 +13588,6 @@
         "@babel/plugin-transform-dotall-regex": "^7.4.4",
         "@babel/types": "^7.4.4",
         "esutils": "^2.0.2"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/preset-react": {
@@ -14247,16 +13660,6 @@
           "version": "7.12.5",
           "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.5.tgz",
           "integrity": "sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ=="
-        },
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
         }
       }
     },
@@ -14277,17 +13680,6 @@
         "lodash": "^4.17.11"
       },
       "dependencies": {
-        "@babel/types": {
-          "version": "7.4.4",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.4.tgz",
-          "integrity": "sha512-dOllgYdnEFOebhkKCjzSVFqw/PmmB8pH6RGOWkY4GsboQNd47b1fBThBSwlHAq9alF9vc1M3+6oqR47R50L0tQ==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2",
-            "lodash": "^4.17.11",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -14306,14 +13698,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0.tgz",
-      "integrity": "sha512-5tPDap4bGKTLPtci2SUl/B7Gv8RnuJFuQoWx26RJobS0fFrz4reUA3JnwIM+HVHEmWE0C1mzKhDtTp8NsWY02Q==",
-      "dev": true,
+      "version": "7.28.2",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.2.tgz",
+      "integrity": "sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==",
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.10",
-        "to-fast-properties": "^2.0.0"
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
       }
     },
     "@cnakazawa/watch": {
@@ -14638,19 +14028,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
-      },
-      "dependencies": {
-        "@babel/types": {
-          "version": "7.12.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.6.tgz",
-          "integrity": "sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@types/body-parser": {
@@ -15308,6 +14685,15 @@
         }
       }
     },
+    "babel-plugin-react-compiler": {
+      "version": "19.1.0-rc.2",
+      "resolved": "https://registry.npmjs.org/babel-plugin-react-compiler/-/babel-plugin-react-compiler-19.1.0-rc.2.tgz",
+      "integrity": "sha512-kSNA//p5fMO6ypG8EkEVPIqAjwIXm5tMjfD1XRPL/sRjYSbJ6UsvORfaeolNWnZ9n310aM0xJP7peW26BuCVzA==",
+      "dev": true,
+      "requires": {
+        "@babel/types": "^7.26.0"
+      }
+    },
     "babel-plugin-ttag": {
       "version": "1.8.16",
       "resolved": "https://registry.npmjs.org/babel-plugin-ttag/-/babel-plugin-ttag-1.8.16.tgz",
@@ -15324,21 +14710,6 @@
         "plural-forms": "^0.5.3"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.12.11",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-          "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw=="
-        },
-        "@babel/types": {
-          "version": "7.12.12",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.12.tgz",
-          "integrity": "sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==",
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.12.11",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "babel-plugin-macros": {
           "version": "2.8.0",
           "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
@@ -17341,17 +16712,6 @@
         "semver": "^6.0.0"
       },
       "dependencies": {
-        "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -20913,11 +20273,6 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/walk": "^2.3.0",
     "@types/yargs": "8.0.2",
     "babel-core": "^7.0.0-bridge.0",
+    "babel-plugin-react-compiler": "^19.1.0-rc.2",
     "husky": "^0.14.3",
     "jest": "^24.9.0",
     "lint-staged": "^5.0.0",

--- a/src/commands/replace.ts
+++ b/src/commands/replace.ts
@@ -12,7 +12,7 @@ async function replace(
     pofile: string,
     out: string,
     srcPath: string,
-    overrideOpts?: c3poTypes.TtagOpts
+    overrideOpts?: c3poTypes.TtagOpts & c3poTypes.CliOpts
 ) {
     const progress: c3poTypes.Progress = ora(
         `[ttag] replacing source files with translations ...`
@@ -25,7 +25,9 @@ async function replace(
     if (overrideOpts) {
         ttagOpts = Object.assign(ttagOpts, overrideOpts);
     }
-    const babelOptions = makeBabelConf(ttagOpts);
+    const babelOptions = makeBabelConf(ttagOpts, {
+        useProjectBabelrc: overrideOpts && overrideOpts.useProjectBabelrc
+    });
     const transformFn: TransformFn = file => {
         const relativePath = path.relative(srcPath, file);
         const resultPath = path.join(out, relativePath);

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -36,9 +36,10 @@ export const defaultPresets: ConfigItem[] = [
     presetReact
 ];
 
-export function makeBabelConf(ttagOpts: ttagTypes.TtagOpts): TransformOptions {
+export function makeBabelConf(ttagOpts: ttagTypes.TtagOpts, cliOpts: ttagTypes.CliOpts ): TransformOptions {
     return {
-        babelrc: false,
+        babelrc: Boolean(cliOpts.useProjectBabelrc),
+        configFile: Boolean(cliOpts.useProjectBabelrc) ? undefined : false,
         presets: [...defaultPresets],
         plugins: [...defaultPlugins, [babelTtagPlugin, ttagOpts]]
     };

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -38,6 +38,7 @@ export const defaultPresets: ConfigItem[] = [
 
 export function makeBabelConf(ttagOpts: ttagTypes.TtagOpts): TransformOptions {
     return {
+        babelrc: false,
         presets: [...defaultPresets],
         plugins: [...defaultPlugins, [babelTtagPlugin, ttagOpts]]
     };

--- a/src/lib/extract.ts
+++ b/src/lib/extract.ts
@@ -17,7 +17,7 @@ export async function extractAll(
     paths: string[],
     lang: string,
     progress: ttagTypes.Progress,
-    overrideOpts?: ttagTypes.TtagOpts,
+    overrideOpts?: ttagTypes.TtagOpts & ttagTypes.CliOpts,
     rcOpts?: ttagTypes.TtagRc
 ): Promise<string> {
     const tmpFile = tmp.fileSync();
@@ -32,7 +32,9 @@ export async function extractAll(
     if (overrideOpts) {
         ttagOpts = mergeOpts(ttagOpts, overrideOpts);
     }
-    const babelOptions = makeBabelConf(ttagOpts);
+    const babelOptions = makeBabelConf(ttagOpts, {
+        useProjectBabelrc: overrideOpts && overrideOpts.useProjectBabelrc
+    });
     const transformFn: TransformFn = filepath => {
         try {
             switch (extname(filepath)) {

--- a/src/lib/ttagPluginOverride.ts
+++ b/src/lib/ttagPluginOverride.ts
@@ -24,11 +24,19 @@ const sortByMsgidDescr = `boolean - The resulting output will be sorted alphabet
     "#configsortbymsgid"
 )}`;
 
+const useProjectBabelrcDescription = `boolean - Ttag cli will use projects babel config files. ${doc(
+    "#useProjectBabelrcDescription"
+)}`;
+
 const OPTS: { [k: string]: { description: string; boolean?: boolean } } = {
     discover: { description: discoverDescription },
     numberedExpressions: { description: numberedExpressionsDescr },
     extractLocation: { description: extractLocationDescr },
-    sortByMsgid: { description: sortByMsgidDescr, boolean: true }
+    sortByMsgid: { description: sortByMsgidDescr, boolean: true },
+    useProjectBabelrc: {
+        description: useProjectBabelrcDescription,
+        boolean: true
+    }
 };
 
 function hasOverrides(argv: yargs.Arguments): boolean {
@@ -57,6 +65,8 @@ export function parseTtagPluginOpts(
             extendedOpts["extract"] = { location: argv[opt] };
         } else if (opt === "sortByMsgid") {
             extendedOpts.sortByMsgid = true;
+        } else if (opt === "useProjectBabelrc") {
+            extendedOpts.useProjectBabelrc = true;
         } else {
             extendedOpts[opt] = argv[opt];
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,10 @@ export type TtagOpts = {
     addComments?: boolean;
 };
 
+export type CliOpts = {
+    useProjectBabelrc?: boolean;
+};
+
 export type Progress = {
     text: string;
     start(text?: string | undefined): any;

--- a/tests/commands/test_update.ts
+++ b/tests/commands/test_update.ts
@@ -151,3 +151,18 @@ test('should transpile with react compiler enabled', () => {
     expect(result).toContain('msgid_plural "месяца"');
     tmpFile.removeCallback();
 })
+
+test("should apply useProjectBabelrc opt and fail with react compiler", () => {
+    const tmpFile = tmp.fileSync();
+    fs.writeFileSync(tmpFile.name, originalPo);
+    try {
+        execSync(
+            `ts-node src/index.ts update --useProjectBabelrc --lang ru ${tmpFile.name} ${reactCompilerTest}`
+        );
+        expect(false).toBe(true); // must fail anyway
+    } catch (err) {
+        expect(err.status).toBe(1);
+    } finally {
+        tmpFile.removeCallback();
+    }
+});

--- a/tests/commands/test_update.ts
+++ b/tests/commands/test_update.ts
@@ -137,3 +137,17 @@ test("Should get exception about same key", () => {
         expect(err.stderr.toString()).toContain(errMessage);
     }
 });
+
+const reactCompilerTest = path.resolve(
+    __dirname,
+    "../fixtures/updateReactCompilerTest/index.tsx"
+);
+
+test('should transpile with react compiler enabled', () => {
+    const tmpFile = tmp.fileSync();
+    fs.writeFileSync(tmpFile.name, originalPo);
+    execSync(`ts-node src/index.ts update --lang ru ${tmpFile.name} ${reactCompilerTest}`);
+    const result = fs.readFileSync(tmpFile.name).toString();
+    expect(result).toContain('msgid_plural "месяца"');
+    tmpFile.removeCallback();
+})

--- a/tests/fixtures/updateReactCompilerTest/.babelrc.js
+++ b/tests/fixtures/updateReactCompilerTest/.babelrc.js
@@ -1,0 +1,9 @@
+module.exports = function(api) {
+    api.cache(true);
+    return {
+        presets: [],
+        plugins: [
+            ["babel-plugin-react-compiler"]
+        ]
+    };
+};

--- a/tests/fixtures/updateReactCompilerTest/index.tsx
+++ b/tests/fixtures/updateReactCompilerTest/index.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { msgid, ngettext, t } from 'ttag';
+import { Box } from '@prom-ui/core/Box';
+import { Text } from '@prom-ui/core/Text';
+
+import type { Product } from 'portable/types/auto';
+
+type CompanyType = {
+    title: string;
+    companies: { name: string; address: string }[];
+};
+
+type WarrantyType = {
+    warrantyPeriod: Product['warranty_period'];
+};
+
+const WarrantyPeriodRow: React.FC<WarrantyType> = ({ warrantyPeriod }) => {
+    if (!warrantyPeriod) return null;
+    const monthText = ngettext(msgid`месяц`, `месяца`, `месяцев`, warrantyPeriod);
+    return (
+        <Box box-margin-bottom='l'>
+            <Box box-margin-bottom='s'>
+                <Text text-weight='bold'>{t`Гарантийный срок`}</Text>
+            </Box>
+            <Box
+                box-margin-bottom='s'
+                box-padding-left='l'
+            >
+                {warrantyPeriod}
+                &nbsp;
+                {monthText}
+            </Box>
+        </Box>
+    );
+};


### PR DESCRIPTION
Isolate ttag-cli from project Babel config by default, add opt-in flag for using project config
+ added option to override this behaviour - *useProjectBabelrc*