### PR TITLE
chore: update Vue packages repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,20 @@
+---
+name: CI
+
+"on":
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - run: npm i
+      - run: npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -8045,7 +8045,7 @@
     },
     "node_modules/lodash.mapvalues": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "node_modules/lodash.memoize": {
@@ -10814,7 +10814,7 @@
     },
     "node_modules/ts-node": {
       "version": "3.3.0",
-      "resolved": "https://registry.npm.taobao.org/ts-node/download/ts-node-3.3.0.tgz?cache=0&sync_timestamp=1584844507755&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fts-node%2Fdownload%2Fts-node-3.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ts-node/download/ts-node-3.3.0.tgz?cache=0&sync_timestamp=1584844507755&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fts-node%2Fdownload%2Fts-node-3.3.0.tgz",
       "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
       "dev": true,
       "dependencies": {
@@ -11159,7 +11159,7 @@
     },
     "node_modules/vue-sfc-parser": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/vue-sfc-parser/download/vue-sfc-parser-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-sfc-parser/download/vue-sfc-parser-0.1.2.tgz",
       "integrity": "sha1-9D3LnqpN7uEpDAwQ278OBrBPvqs=",
       "dependencies": {
         "lodash.mapvalues": "^4.6.0"
@@ -18418,7 +18418,7 @@
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
-      "resolved": "https://registry.npm.taobao.org/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
+      "resolved": "https://registry.npmmirror.com/lodash.mapvalues/download/lodash.mapvalues-4.6.0.tgz",
       "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "lodash.memoize": {
@@ -20620,7 +20620,7 @@
     },
     "ts-node": {
       "version": "3.3.0",
-      "resolved": "https://registry.npm.taobao.org/ts-node/download/ts-node-3.3.0.tgz?cache=0&sync_timestamp=1584844507755&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fts-node%2Fdownload%2Fts-node-3.3.0.tgz",
+      "resolved": "https://registry.npmmirror.com/ts-node/download/ts-node-3.3.0.tgz?cache=0&sync_timestamp=1584844507755&other_urls=https%3A%2F%2Fregistry.npmmirror.com%2Fts-node%2Fdownload%2Fts-node-3.3.0.tgz",
       "integrity": "sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=",
       "dev": true,
       "requires": {
@@ -20892,7 +20892,7 @@
     },
     "vue-sfc-parser": {
       "version": "0.1.2",
-      "resolved": "https://registry.npm.taobao.org/vue-sfc-parser/download/vue-sfc-parser-0.1.2.tgz",
+      "resolved": "https://registry.npmmirror.com/vue-sfc-parser/download/vue-sfc-parser-0.1.2.tgz",
       "integrity": "sha1-9D3LnqpN7uEpDAwQ278OBrBPvqs=",
       "requires": {
         "lodash.mapvalues": "^4.6.0"


### PR DESCRIPTION
Fixes `npm i` issue:


```
🦐/c/ttag-cli (master) [127]> npm i
npm error code CERT_HAS_EXPIRED
npm error errno CERT_HAS_EXPIRED
npm error request to https://registry.npm.taobao.org/vue-sfc-parser/download/vue-sfc-parser-0.1.2.tgz failed, reason: certificate has expired npm error
```

Solution from https://github.com/vuejs/vue-cli/issues/7459#issuecomment-2811793997