### PR TITLE
Support TC39 decorators

### DIFF
--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -13,7 +13,7 @@ import * as babelTtagPlugin from "babel-plugin-ttag";
 import * as babelPluginDecorators from "@babel/plugin-proposal-decorators";
 
 export const defaultPlugins: ConfigItem[] = [
-    [babelPluginDecorators, { legacy: true }],
+    [babelPluginDecorators, { version: "2023-11" }],
     exportDefaultFromPlugin,
 ];
 

--- a/tests/commands/__snapshots__/test_extract.ts.snap
+++ b/tests/commands/__snapshots__/test_extract.ts.snap
@@ -192,6 +192,18 @@ msgstr \\"\\"
 "
 `;
 
+exports[`extract with decorator 1`] = `
+"msgid \\"\\"
+msgstr \\"\\"
+\\"Content-Type: text/plain; charset=utf-8\\\\n\\"
+\\"Plural-Forms: nplurals=2; plural=(n!=1);\\\\n\\"
+
+#: tests/fixtures/testDecoratorParse.js:3
+msgid \\"hi from a module with decorators\\"
+msgstr \\"\\"
+"
+`;
+
 exports[`should extract in the alphabetical order (sortByMsgid) 1`] = `
 "msgid \\"\\"
 msgstr \\"\\"

--- a/tests/commands/test_extract.ts
+++ b/tests/commands/test_extract.ts
@@ -8,6 +8,10 @@ const baseTestPath = path.resolve(__dirname, "../fixtures/baseTest");
 const sortByMsgidPath = path.resolve(__dirname, "../fixtures/sortByMsgidTest");
 const ukTestPath = path.resolve(__dirname, "../fixtures/ukLocaleTest");
 const jsxPath = path.resolve(__dirname, "../fixtures/testJSXParse.jsx");
+const decoratorPath = path.resolve(
+    __dirname,
+    "../fixtures/testDecoratorParse.js"
+);
 const vuePath = path.resolve(__dirname, "../fixtures/vueTest/testVueParse.vue");
 const vuePath2 = path.resolve(
     __dirname,
@@ -44,6 +48,12 @@ test("extract base case", () => {
 
 test("extract from jsx", () => {
     execSync(`ts-node src/index.ts extract -o ${potPath} ${jsxPath}`);
+    const result = fs.readFileSync(potPath).toString();
+    expect(result).toMatchSnapshot();
+});
+
+test("extract with decorator", () => {
+    execSync(`ts-node src/index.ts extract -o ${potPath} ${decoratorPath}`);
     const result = fs.readFileSync(potPath).toString();
     expect(result).toMatchSnapshot();
 });

--- a/tests/fixtures/testDecoratorParse.js
+++ b/tests/fixtures/testDecoratorParse.js
@@ -1,0 +1,12 @@
+import { t } from 'ttag';
+
+const x = t`hi from a module with decorators`
+
+@myClassDecorator
+class MyClass {
+  @myFieldDecorator myField;
+  @myAccessorDecortor accessor myAccessor;
+  @myGetterDecorator get myGetter() { }
+  @mySetterDecorator set mySetter(x) { }
+  @methodDecorator hi() { }
+}


### PR DESCRIPTION
This commit adapts the babel configuration to support the syntax propsed by the TC39 decorator proposal: https://github.com/tc39/proposal-decorators

This proposal is now stage 3 (recommended to be implemented). It is likely that this is the syntax that will be used for a decorators for a long time.

The syntax is similar (using the `@decorator`) to the "legacy" decorators so this should be backward compatible with code using the old decorators.

Fixes #168.