### PR TITLE
Skip duplicate key check on po2json when using verbose key format

### DIFF
--- a/src/commands/po2json.ts
+++ b/src/commands/po2json.ts
@@ -17,11 +17,13 @@ export default function po2json(
     let poData: PoData | PoDataCompact = parse(
         fs.readFileSync(path).toString()
     );
-    const errMessage = checkDuplicateKeys(poData);
+    if (format === "compact") {
+        const errMessage = checkDuplicateKeys(poData);
 
-    if (errMessage) {
-        progress.fail(errMessage);
-        process.exit(1);
+        if (errMessage) {
+            progress.fail(errMessage);
+            process.exit(1);
+        }
     }
     const messages = iterateTranslations(poData.translations);
     if (!nostrip) {

--- a/tests/commands/test_po2js.ts
+++ b/tests/commands/test_po2js.ts
@@ -1,5 +1,5 @@
 import * as path from "path";
-import { execSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 
 const poPath = path.resolve(__dirname, "../fixtures/po2jsTest/po2js.po");
 
@@ -39,7 +39,7 @@ const errMessage =
     " this potentially can lead to translation loss.";
 
 const poPath2 = path.resolve(__dirname, "../fixtures/checkTest/same_key.po");
-test("Should get exception about same key", () => {
+test("should get exception about same key for compact format", () => {
     try {
         execSync(
             `ts-node src/index.ts po2json --format=compact -n ${poPath2}`,
@@ -52,4 +52,17 @@ test("Should get exception about same key", () => {
         expect(err.status).toBe(1);
         expect(err.stderr.toString()).toContain(errMessage);
     }
+});
+
+test("should NOT get exception about same key for verbose format", () => {
+    const result = spawnSync(
+        `ts-node src/index.ts po2json --format=verbose -n ${poPath2}`,
+        {
+            shell: true,
+            encoding: "utf8"
+        }
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).not.toContain(errMessage);
 });


### PR DESCRIPTION
Fixes #164.